### PR TITLE
update build.gradle files, gradle-wrapper.properties and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Used in a Udacity course in the Android Basics Nanodegree by Google.
 Pre-requisites
 --------------
 
-- Android SDK v24
-- Android Build Tools v23.0.3
-- Android Support Repository v24.1.1
+- Android SDK v26.0.2
+- Android Build Tools v27.0.3
+- Android Support Repository v27.0.2
 
 Getting Started
 ---------------
@@ -29,7 +29,7 @@ submitting a pull request through GitHub. Please see CONTRIBUTING.md for more de
 License
 -------
 
-Copyright 2016 The Android Open Source Project, Inc.
+Copyright 2018 The Android Open Source Project, Inc.
 
 Licensed to the Apache Software Foundation (ASF) under one or more contributor
 license agreements.  See the NOTICE file distributed with this work for

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,20 @@
 apply plugin: 'com.android.application'
 
+ext {
+    buildToolsV = "27.0.3"
+    supportLibV = "27.0.2"
+}
+
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+
+    compileSdkVersion 27
+    buildToolsVersion buildToolsV
 
     defaultConfig {
         applicationId "com.example.android.pets"
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 27
+
         versionCode 1
         versionName "1.0"
     }
@@ -19,7 +26,8 @@ android {
     }
 }
 
+
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.1.1'
-    compile 'com.android.support:design:24.1.1'
+    implementation "com.android.support:appcompat-v7:$supportLibV"
+    implementation "com.android.support:design:$supportLibV"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +15,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
1. update buildToolVersion to 27.0.3, supportLibVersion to 27.0.2
2. use ext{} block
3. update distribution url to ../distributions/gradle-4.1-all.zip
4. update buildToolVersion, supportLibVersion, sdk version and copyright year in README.md file

Signed-off-by: jainamjhaveri <engineerjainam@gmail.com>